### PR TITLE
Help update

### DIFF
--- a/inventories/sample/group_vars/nas.yml
+++ b/inventories/sample/group_vars/nas.yml
@@ -9,10 +9,61 @@
 
 # Add your all.yml config overrides to this file. See group_vars/all.yml for all possible settings.
 
-# Example options
-ansible_nas_hostname: ansible-nas
-ansible_nas_timezone: Etc/UTC
+###
+### Example options
+###
 
-## Enable some applications
-heimdall_enabled: true
+ansible_nas_hostname: yourserver
+ansible_nas_timezone: Europe/London
+ansible_nas_user: youruser                    # Will be added to the docker group to give user command line access to docker
+ansible_nas_email: your@email                 # Your email and domain, used for Let's Encrypt SSL certs
+ansible_nas_domain: yourdomain                # Applications will have subdomain SSL certificates created if Traefik is enabled, e.g. ansible-nas.<your-domain>, nextcloud.<your-domain>
+ansible_python_interpreter: /usr/bin/python3  # What version of python ansible should use on target system (path to spesific binary)
+docker_home: /home/youruser/docker            # docker data
+samba_shares_root: /mnt/Media                 # media data
+traefik_enabled: true
+
+###
+### Secrets
+###
+
+cloudflare_dns_api_token: yourapitoken
+traefik_google_client_id: yourclientid                                            # client ID from the Google project
+traefik_google_client_secret: yourclientsecret                                    # client secret from the Google project
+traefik_forwardauth_secret: yourcookiesecret                                      # cookie secret
+traefik_forwardauth_whitelist: your@email                                         # enabled email
+plex_claim: claim-your claim                                                      # https://www.plex.tv/claim/
+
+###
+### APPLICATION - overrides
+###
+
+### I prefer homepage - https://github.com/benphelps/homepage/ - as a front end
+
+### Application available externally, so I also put this behind Google Oauth2
+homepage_enabled: true                        # enable the actual application
+homepage_available_externally: true           # make it available externally
+
+### Application available externally, so I also put this behind Google Oauth2
 portainer_enabled: true
+portainer_available_externally: true
+
+### Application available externally (consider adding oauth block in ansible-nas-docker/roles/sonarr/tasks/main.yml)
+sonarr_enabled: true
+sonarr_available_externally: true
+
+## Application available externally (consider adding oauth block in ansible-nas-docker/roles/radarr/tasks/main.yml)
+radarr_enabled: true
+radarr_available_externally: true
+
+## Application is not available externally
+transmission_enabled: true
+transmission_available_externally: false
+
+## Application uses Plex-authentication, therefore Oauth omited
+overseerr_enabled: true
+overseerr_available_externally: true
+
+## Application uses Plex-authentication, therefore Oauth omited
+plex_enabled: true
+plex_available_externally: true

--- a/roles/homepage/defaults/main.yml
+++ b/roles/homepage/defaults/main.yml
@@ -1,24 +1,17 @@
 ---
 homepage_enabled: false
-homepage_hostname: homepage
+homepage_available_externally: false
 
-homepage_docker_image: "ghcr.io/benphelps/homepage:latest"
+# directories
+homepage_data_directory: "{{ docker_home }}/homepage"
 
-homepage_users:
-  - username: "{{ ansible_nas_user }}"
-    password: "topsecret"
-    sudo: "Y"
+# networking
+homepage_port: "3000"
+homepage_hostname: "homepage"
 
 # uid / gid
 homepage_user_id: "0"
 homepage_group_id: "0"
 
-# Directories
-homepage_data_directory: "{{ docker_home }}/homepage"
-
-# Networking
-homepage_port: 3000
-
-# Container
+# specs
 homepage_memory: 1g
-homepage_container_name: homepage

--- a/roles/homepage/tasks/main.yml
+++ b/roles/homepage/tasks/main.yml
@@ -11,13 +11,12 @@
 - name: Homepage Container
   docker_container:
     name: homepage
-    image: "{{ homepage_docker_image }}"
+    image: ghcr.io/benphelps/homepage:latest
     pull: true
     volumes:
-      # - "{{ homepage_data_directory }}/users.txt:/root/createusers.txt:ro"
       - "{{ homepage_data_directory }}/config:/app/config"
       - "{{ homepage_data_directory }}/icons:/app/public/icons"
-      - "/var/run/docker.sock:/var/run/docker.sock"
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
     ports:
       - "{{ homepage_port }}:3000"
     privileged: true

--- a/roles/portainer/tasks/main.yml
+++ b/roles/portainer/tasks/main.yml
@@ -26,3 +26,4 @@
       traefik.http.routers.portainer.tls.domains[0].main: "{{ ansible_nas_domain }}"
       traefik.http.routers.portainer.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"
       traefik.http.services.portainer.loadbalancer.server.port: "9000"
+      traefik.http.routers.portainer.middlewares: traefik-forward-auth


### PR DESCRIPTION
Changes compared to the original:

- added option for forward authentication with traefik (also added neccesary secret examples to ansible-nas-docker/inventories/sample/group_vars/nas.yml)
- added Homepage (https://github.com/benphelps/homepage/) to the stack
- made portainer / homepage using Google Oauth2 (considering for other apps)
- minor fix in deluge path (it was pointing to `/root/Downloads`, so `/downloads` was going outside of the `deluge_download_directory` - filling my disk :(
- various small tweaks I can't bother to remember :)

